### PR TITLE
Add vscode/settings.json with preference for using node_modules TS 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
Adds a `.vscode/settings.json` config 
This config (optionally) hints to the Typescript extension that the project's Typescript version (5.7.1-rc currently) should be used. As this repo is a tutorial HelloWorld mod, my hope is that it might mitigate (yet another) [confusing] roadblock for would-be modders in the event of some TS incompatibility.